### PR TITLE
SS4 vendor module, typo fix and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ SilverStripe\CMS\Model\RedirectorPage:
     enabled: false
 ```
 
+The maximum number of images can be also specified in the config using the following syntax (default is 20 for a page):
+
+```php
+SilverStripe\Blog\Model\BlogPost:
+  images:
+    count: 50
+```
+
+
 You can add images to any DataObject too, just extend DataObject with ObjectImagesExtension.
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,30 @@
 {
-    "name": "webmaxsk/maximages",
-    "description": "Simple image gallery for any dataobject",
-    "type": "silverstripe-module",
-    "license": "BSD-3-Clause",
-    "keywords": ["silverstripe", "gallery", "photos", "images"],
-    "authors": [
-        {
-            "name": "Pali Ondras",
-            "email": "ondras@webmax.sk"
-        },
-        {
-            "name": "Rastislav Brandobur",
-            "email": "brandobur@webmax.sk"
-        }
-    ],
-    "require": {
-        "silverstripe/framework": "^4.0",
-        "bummzack/sortablefile": "^2.0"
-    },
-    "suggest": {
-        "heyday/silverstripe-optimisedimage": "*",
-        "jonom/focuspoint": "*"
-    }
+ "name": "webmaxsk/maximages",
+ "description": "Simple image gallery for any dataobject",
+ "type": "silverstripe-vendormodule",
+ "license": "BSD-3-Clause",
+ "keywords": ["silverstripe", "gallery", "photos", "images"],
+ "authors": [
+  {
+   "name": "Pali Ondras",
+   "email": "ondras@webmax.sk"
+  },
+  {
+   "name": "Rastislav Brandobur",
+   "email": "brandobur@webmax.sk"
+  }
+ ],
+ "require": {
+  "silverstripe/framework": "^4.0",
+  "bummzack/sortablefile": "^2.0"
+ },
+ "suggest": {
+  "heyday/silverstripe-optimisedimage": "*",
+  "jonom/focuspoint": "*"
+ },
+ "autoload": {
+  "psr-4": {
+   "Webmaxsk\\MaxImages\\": "src/"
+  }
+ }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,30 @@
 {
- "name": "webmaxsk/maximages",
- "description": "Simple image gallery for any dataobject",
- "type": "silverstripe-vendormodule",
- "license": "BSD-3-Clause",
- "keywords": ["silverstripe", "gallery", "photos", "images"],
- "authors": [
-  {
-   "name": "Pali Ondras",
-   "email": "ondras@webmax.sk"
+  "name": "webmaxsk/maximages",
+  "description": "Simple image gallery for any dataobject",
+  "type": "silverstripe-vendormodule",
+  "license": "BSD-3-Clause",
+  "keywords": ["silverstripe", "gallery", "photos", "images"],
+  "authors": [
+   {
+    "name": "Pali Ondras",
+    "email": "ondras@webmax.sk"
+   },
+   {
+    "name": "Rastislav Brandobur",
+    "email": "brandobur@webmax.sk"
+   }
+  ],
+  "require": {
+   "silverstripe/framework": "^4.0",
+   "bummzack/sortablefile": "^2.0"
   },
-  {
-   "name": "Rastislav Brandobur",
-   "email": "brandobur@webmax.sk"
+  "suggest": {
+   "heyday/silverstripe-optimisedimage": "*",
+   "jonom/focuspoint": "*"
+  },
+  "autoload": {
+   "psr-4": {
+    "Webmaxsk\\MaxImages\\": "src/"
+   }
   }
- ],
- "require": {
-  "silverstripe/framework": "^4.0",
-  "bummzack/sortablefile": "^2.0"
- },
- "suggest": {
-  "heyday/silverstripe-optimisedimage": "*",
-  "jonom/focuspoint": "*"
- },
- "autoload": {
-  "psr-4": {
-   "Webmaxsk\\MaxImages\\": "src/"
-  }
- }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,18 +5,18 @@
     "license": "BSD-3-Clause",
     "keywords": ["silverstripe", "gallery", "photos", "images"],
     "authors": [
-     {
-      "name": "Pali Ondras",
-      "email": "ondras@webmax.sk"
-     },
-     {
-      "name": "Rastislav Brandobur",
-      "email": "brandobur@webmax.sk"
-     }
+        {
+             "name": "Pali Ondras",
+             "email": "ondras@webmax.sk"
+        },
+        {
+             "name": "Rastislav Brandobur",
+             "email": "brandobur@webmax.sk"
+        }
     ],
     "require": {
-     "silverstripe/framework": "^4.0",
-     "bummzack/sortablefile": "^2.0"
+        "silverstripe/framework": "^4.0",
+        "bummzack/sortablefile": "^2.0"
     },
     "suggest": {
      "heyday/silverstripe-optimisedimage": "*",

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
     "keywords": ["silverstripe", "gallery", "photos", "images"],
     "authors": [
         {
-             "name": "Pali Ondras",
-             "email": "ondras@webmax.sk"
+            "name": "Pali Ondras",
+            "email": "ondras@webmax.sk"
         },
         {
-             "name": "Rastislav Brandobur",
-             "email": "brandobur@webmax.sk"
+            "name": "Rastislav Brandobur",
+            "email": "brandobur@webmax.sk"
         }
     ],
     "require": {
@@ -19,8 +19,8 @@
         "bummzack/sortablefile": "^2.0"
     },
     "suggest": {
-     "heyday/silverstripe-optimisedimage": "*",
-     "jonom/focuspoint": "*"
+        "heyday/silverstripe-optimisedimage": "*",
+        "jonom/focuspoint": "*"
     },
     "autoload": {
      "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,30 @@
 {
-  "name": "webmaxsk/maximages",
-  "description": "Simple image gallery for any dataobject",
-  "type": "silverstripe-vendormodule",
-  "license": "BSD-3-Clause",
-  "keywords": ["silverstripe", "gallery", "photos", "images"],
-  "authors": [
-   {
-    "name": "Pali Ondras",
-    "email": "ondras@webmax.sk"
-   },
-   {
-    "name": "Rastislav Brandobur",
-    "email": "brandobur@webmax.sk"
-   }
-  ],
-  "require": {
-   "silverstripe/framework": "^4.0",
-   "bummzack/sortablefile": "^2.0"
-  },
-  "suggest": {
-   "heyday/silverstripe-optimisedimage": "*",
-   "jonom/focuspoint": "*"
-  },
-  "autoload": {
-   "psr-4": {
-    "Webmaxsk\\MaxImages\\": "src/"
-   }
-  }
+    "name": "webmaxsk/maximages",
+    "description": "Simple image gallery for any dataobject",
+    "type": "silverstripe-vendormodule",
+    "license": "BSD-3-Clause",
+    "keywords": ["silverstripe", "gallery", "photos", "images"],
+    "authors": [
+     {
+      "name": "Pali Ondras",
+      "email": "ondras@webmax.sk"
+     },
+     {
+      "name": "Rastislav Brandobur",
+      "email": "brandobur@webmax.sk"
+     }
+    ],
+    "require": {
+     "silverstripe/framework": "^4.0",
+     "bummzack/sortablefile": "^2.0"
+    },
+    "suggest": {
+     "heyday/silverstripe-optimisedimage": "*",
+     "jonom/focuspoint": "*"
+    },
+    "autoload": {
+     "psr-4": {
+      "Webmaxsk\\MaxImages\\": "src/"
+     }
+    }
 }

--- a/src/ObjectImagesExtension.php
+++ b/src/ObjectImagesExtension.php
@@ -55,7 +55,7 @@ class ObjectImagesExtension extends DataExtension {
                 $imageField->setDescription(sprintf(_t('Object.IMAGESUPLOADLIMIT','Images count limit: %s'), $limit));
 
                 if ($this->owner->Sorter == 'SortOrder')
-                    $message = _t('Object.IMAGESUPLOADHEADING', '<span style="color: green">Sort images by draging thumbnail</span>');
+                    $message = _t('Object.IMAGESUPLOADHEADING', '<span style="color: green">Sort images by dragging thumbnail</span>');
                 else
                     $message = _t('Object.IMAGESSORTERNOTICE', 'Correct image sorting is visible on frontend only (if Sort by = Title, ID)');
 


### PR DESCRIPTION
There was a minor typo in the hinting for the image upload screen.  I also thought it might be helpful to add an example of how to configure the image count.

I've suggested the move to a vendor module and added the autoloader info to composer, in line with the move to this format in SS4 modules.